### PR TITLE
Change text shadow color

### DIFF
--- a/lib/shield.svg
+++ b/lib/shield.svg
@@ -115,12 +115,12 @@
       d="M25,19.25h42c1.657,0,3-1.343,3-3v-12c0-1.657-1.343-3-3-3H30V19.25z"
       id="statusBackground" />
     <g id="statusText">
-      <g opacity="1" id="dropShadowStatusText">
+      <g opacity="0.5" id="dropShadowStatusText">
         <text
           x="34"
           y="14.8"
           transform="scale(1,0.93968341)"
-          fill="#23630A"
+          fill="#000000"
           font-family="Open Sans"
           font-size="10"
           id="statusText1">||status||</text>


### PR DESCRIPTION
When the background of the badge is not green, the text shadow looks a little weird (the change is easier to see in high resolution):

![badge_previous](https://f.cloud.github.com/assets/408035/2147564/2a1eea98-93d4-11e3-8dc2-d83ba78d02de.png)

With this fix, it looks better:

![badge_now](https://f.cloud.github.com/assets/408035/2147568/34e8514e-93d4-11e3-9ece-e92c89018b10.png)
